### PR TITLE
feat: make default UART baudrate after power-up configurable

### DIFF
--- a/main/interface/uart/Kconfig
+++ b/main/interface/uart/Kconfig
@@ -27,3 +27,7 @@ config AT_UART_PORT_CTS_PIN
     default 15
     depends on AT_BASE_ON_UART
 
+config AT_UART_BAUDRATE
+    int "uart default baudrate"
+    default 115200
+    depends on AT_BASE_ON_UART

--- a/main/interface/uart/at_uart_task.c
+++ b/main/interface/uart/at_uart_task.c
@@ -160,7 +160,7 @@ static void at_uart_init(void)
 {
     at_nvm_uart_config_struct uart_nvm_config;
     uart_config_t uart_config = {
-        .baud_rate = 115200,
+        .baud_rate = CONFIG_AT_UART_BAUDRATE,
         .data_bits = UART_DATA_8_BITS,
         .parity = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,
@@ -193,7 +193,7 @@ static void at_uart_init(void)
             uart_config.flow_ctrl = uart_nvm_config.flow_control;
         }
     } else {
-        uart_nvm_config.baudrate = 115200;
+        uart_nvm_config.baudrate = CONFIG_AT_UART_BAUDRATE;
         uart_nvm_config.data_bits = UART_DATA_8_BITS;
         uart_nvm_config.flow_control = UART_HW_FLOWCTRL_RTS;
         uart_nvm_config.parity = UART_PARITY_DISABLE;


### PR DESCRIPTION
This patch allows a custom setting of the default UART baudrate of the AT firmware module in the ESP32.
The default UART baudrate is set to 115200 which was also the permanent default before.